### PR TITLE
feature: scripts to update to Debian 11 (bullseye) #35

### DIFF
--- a/upgrade_scripts/sources.list.bullseye
+++ b/upgrade_scripts/sources.list.bullseye
@@ -1,0 +1,6 @@
+deb http://ftp.us.debian.org/debian bullseye main contrib non-free
+deb-src http://ftp.us.debian.org/debian bullseye main contrib non-free
+deb http://ftp.us.debian.org/debian/ bullseye-updates main contrib non-free
+deb-src http://ftp.us.debian.org/debian/ bullseye-updates main contrib non-free
+deb http://security.debian.org/debian-security bullseye-security main contrib non-free
+deb-src http://security.debian.org/debian-security bullseye-security main contrib non-free

--- a/upgrade_scripts/upgrade_4_bullseye.sh
+++ b/upgrade_scripts/upgrade_4_bullseye.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+if [[ "$(id -u)" != "0" ]]; then
+   echo "Please run me as root!"
+   exit 1
+fi
+cp sources.list.bullseye /etc/apt/sources.list
+apt update
+apt-get -y -oAPT::Force-LoopBreak=1 dist-upgrade

--- a/upgrading.md
+++ b/upgrading.md
@@ -9,9 +9,10 @@ To upgrade to novena-next:
 4. Run upgrade_1_prep.sh
 5. Run upgrade_2_stretch.sh then reboot. (Skip if you're on Stretch already)
 6. Run upgrade_3_buster.sh then reboot. (Skip if you're on Buster already)
-7. Run upgrade_4_apt.sh then reboot. (Skip reboot if upgrading kernel next)
+7. Run upgrade_4_bullseye.sh then reboot. (Skip if you're on Bullseye already)
+8. Run upgrade_4_apt.sh then reboot. (Skip reboot if upgrading kernel next)
 
-You should now have an up to date Buster system with a newer kernel.
+You should now have an up to date Bullseye system with a newer kernel.
 
 Installing the beta 4.19 kernel
 -------------------------------


### PR DESCRIPTION
Tested and working as expected. Documentation updated accordingly.

I didn't renumber the `upgrade_4_apt.sh` script because I feel that adding the extra apt repo is orthogonal to upgrading the OS (running them in the reverse order would work just fine).  If renumbering does occur, it'd be worth considering removing `upgrade_1_prep.sh` as well, as that fails with a HTTP status code 404.

The reason I didn't just use `sed` to rewrite the source.list file is because Debian changed the way they handle updates and now there are separate repos for updates versus security patches and the paths section of the URLs are different.  It's not that it couldn't be done with sed, but it'd be ugly and fragile here. I expect that updating to bookworm will be able to use the nice clean `sed` command again.